### PR TITLE
Temporary remove babili-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "babel-loader": "^7.1.1",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-preset-env": "^1.6.0",
-    "babili-webpack-plugin": "^0.1.2",
-    "webpack": "^3.3.0",
+    "webpack": "^3.4.1",
     "webpack-dev-server": "^2.6.1"
   },
   "dependencies": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,4 @@
 const webpack = require('webpack');
-const BabiliWebpackPlugin = require('babili-webpack-plugin');
 
 module.exports = {
 
@@ -51,7 +50,7 @@ module.exports = {
   },
 
   plugins: [
-    new BabiliWebpackPlugin(),
+    new webpack.optimize.UglifyJsPlugin(),
     new webpack.HotModuleReplacementPlugin()
   ]
 


### PR DESCRIPTION
babili-webpack-plugin stopped 91% assets optimization.

But I don't want to use uglify...

this pr remove babili-webpack-plugin. but it's temporary.
